### PR TITLE
Add Chunksize Check During Track Parsing

### DIFF
--- a/include/minimidi/MiniMidi.hpp
+++ b/include/minimidi/MiniMidi.hpp
@@ -1897,7 +1897,7 @@ public:
         cursor(cursor), bufferEnd(bufferEnd), trackNum(trackNum) {};
 
     size_t parse_chunk_len() {
-        auto remaining = [&]() -> size_t {
+        auto remaining = [bufferEnd = this->bufferEnd, cursor = this->cursor]() -> size_t {
             return static_cast<size_t>(bufferEnd - cursor);
         };
 

--- a/include/minimidi/MiniMidi.hpp
+++ b/include/minimidi/MiniMidi.hpp
@@ -1897,19 +1897,27 @@ public:
         cursor(cursor), bufferEnd(bufferEnd), trackNum(trackNum) {};
 
     size_t parse_chunk_len() {
-        while (std::string_view(reinterpret_cast<const char*>(cursor), 4) != MTRK) {
-            const size_t tmpLen = utils::read_msb_bytes(cursor + 4, 4);
-            if (cursor + tmpLen + 8 > bufferEnd) [[unlikely]] {
+        auto remaining = [&]() -> size_t {
+            return static_cast<size_t>(bufferEnd - cursor);
+        };
+
+        while (true) {
+            if (remaining() < 8) [[unlikely]] {
+                throw std::ios_base::failure("MiniMidi: Unexpected EOF while reading chunk header!");
+            }
+            const auto tag = std::string_view(reinterpret_cast<const char*>(cursor), 4);
+            const size_t len = utils::read_msb_bytes(cursor + 4, 4);
+            if (len > remaining() - 8) [[unlikely]] {
                 throw std::ios_base::failure(
-                    "MiniMidi: Unexpected EOF in file! Cursor is "
-                    + std::to_string(cursor + tmpLen + 8 - bufferEnd)
-                    + " bytes beyond the end of buffer with chunk length " + std::to_string(tmpLen)
-                    + "!"
+                    "MiniMidi: Invalid chunk length " + std::to_string(len)
+                    + " (remaining bytes after header: " + std::to_string(remaining() - 8) + ")"
                 );
             }
-            cursor += (8 + tmpLen);
+            if (tag == MTRK) {
+                return len;
+            }
+            cursor += 8 + len;
         }
-        return utils::read_msb_bytes(cursor + 4, 4);
     }
 
     [[nodiscard]] bool done() const { return cursor >= bufferEnd || trackIdx >= trackNum; }


### PR DESCRIPTION
Hello, 

Thank you for your work on this great library! I have noticed that in rare cases, an invalid / out of bounds read occurs when a MIDI file is internally inconsistent (a bad/corrupted MIDI file). A notable example I found is in the [Lakh MIDI dataset](https://colinraffel.com/projects/lmd/) (the `lmd-full` split). In particular, this file: 
- [`lmd_full/1/1a59d7118a473e7e093624f446bf3dbd.mid`](https://github.com/user-attachments/files/25329567/1a59d7118a473e7e093624f446bf3dbd.mid.zip)

In the current codebase of MiniMidi, this file will either trigger a segfault or catch an error related to the status byte. I believe there is some undefined behavior happening, which is why the segfault happens often but not always. I verified this by running the `parsemidi.cpp` example. 

When MiniMidi reads this file, the chunk length is parsed to be `301989888`. In bytes, this is larger than the original file itself, so it is clearly not right. The problem is with this *file*, not the codebase. 

In this PR, I've added a check that the reported chunk size does not go out of bounds, which fixes the segfault. I first saw this while using [symusic](https://github.com/Yikai-Liao/symusic?tab=readme-ov-file), which crashes when reading this file in a multiprocessing context (even with `sanitize_data=True`). I call it like this: 
```python
score = Score.from_midi(
    # lmd_full/1/1a59d7118a473e7e093624f446bf3dbd.mid
    midifile.read_bytes(), ttype=TimeUnit.second, sanitize_data=True
)
```

I'm not sure that my approach here is the best; I am not super familiar with this codebase. if the maintainers have a better idea that will impact performance less, that would be greatly appreciated!